### PR TITLE
Add AI faction spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Projects
+
+This repository contains a minimal example of a simple game framework written in Python. It demonstrates spawning AI factions on a map after the player places the initial settlement and clicks "Begin".
+
+## Running the example
+
+```
+python -m game.game
+```
+
+The number of AI factions and map size are configurable in `game/settings.py`.

--- a/game/game.py
+++ b/game/game.py
@@ -1,0 +1,88 @@
+import random
+from dataclasses import dataclass
+
+from . import settings
+
+@dataclass
+class Position:
+    x: int
+    y: int
+
+@dataclass
+class Settlement:
+    name: str
+    position: Position
+
+@dataclass
+class Faction:
+    name: str
+    settlement: Settlement
+
+class Map:
+    def __init__(self, width: int, height: int):
+        self.width = width
+        self.height = height
+        self.factions = []
+
+    def is_occupied(self, position: Position) -> bool:
+        for faction in self.factions:
+            if faction.settlement.position == position:
+                return True
+        return False
+
+    def distance(self, pos1: Position, pos2: Position) -> float:
+        return ((pos1.x - pos2.x) ** 2 + (pos1.y - pos2.y) ** 2) ** 0.5
+
+    def add_faction(self, faction: Faction):
+        if not self.is_occupied(faction.settlement.position):
+            self.factions.append(faction)
+        else:
+            raise ValueError("Position is already occupied")
+
+    def spawn_ai_factions(self, player_settlement: Settlement):
+        count = settings.AI_FACTION_COUNT
+        spawned = 0
+        attempts = 0
+        while spawned < count and attempts < count * 10:
+            attempts += 1
+            x = random.randint(0, self.width - 1)
+            y = random.randint(0, self.height - 1)
+            pos = Position(x, y)
+            if (
+                not self.is_occupied(pos)
+                and self.distance(pos, player_settlement.position)
+                >= settings.MIN_DISTANCE_FROM_PLAYER
+            ):
+                ai = Faction(name=f"AI #{spawned + 1}", settlement=Settlement(name=f"AI Town {spawned + 1}", position=pos))
+                self.add_faction(ai)
+                spawned += 1
+
+class Game:
+    def __init__(self):
+        self.map = Map(*settings.MAP_SIZE)
+        self.player_faction: Faction | None = None
+
+    def place_initial_settlement(self, x: int, y: int, name: str = "Player"):
+        pos = Position(x, y)
+        if self.map.is_occupied(pos):
+            raise ValueError("Cannot place settlement on occupied location")
+        settlement = Settlement(name="Home", position=pos)
+        self.player_faction = Faction(name=name, settlement=settlement)
+        self.map.add_faction(self.player_faction)
+
+    def begin(self):
+        if not self.player_faction:
+            raise RuntimeError("Player settlement not placed")
+        self.map.spawn_ai_factions(self.player_faction.settlement)
+        print("Game started with factions:")
+        for faction in self.map.factions:
+            print(f"- {faction.name} at {faction.settlement.position}")
+
+def main():
+    game = Game()
+    # Example: player places settlement at (0,0)
+    game.place_initial_settlement(0, 0)
+    game.begin()
+
+if __name__ == "__main__":
+    main()

--- a/game/settings.py
+++ b/game/settings.py
@@ -1,0 +1,10 @@
+# Settings for the game
+
+# Number of AI factions to spawn when the game begins.
+AI_FACTION_COUNT = 3
+
+# Size of the map (width, height)
+MAP_SIZE = (10, 10)
+
+# Minimum distance from player's settlement to spawn AI
+MIN_DISTANCE_FROM_PLAYER = 2


### PR DESCRIPTION
## Summary
- implement a minimal game framework under `game/`
- spawn AI factions automatically after the player starts the game
- provide configurable settings for the number of AI factions and map size
- document how to run the example in the README

## Testing
- `python -m game.game`

------
https://chatgpt.com/codex/tasks/task_e_683fe1209efc832b8a9527c1223cfcbf