### PR TITLE
Add simple persistence with offline gains

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -1,6 +1,8 @@
 import random
 from dataclasses import dataclass
 
+from .persistence import GameState, load_state, save_state
+
 from . import settings
 
 @dataclass
@@ -58,9 +60,12 @@ class Map:
                 spawned += 1
 
 class Game:
-    def __init__(self):
+    def __init__(self, state: GameState | None = None):
         self.map = Map(*settings.MAP_SIZE)
         self.player_faction: Faction | None = None
+        self.state = state or load_state()
+        self.resources = self.state.resources
+        self.population = self.state.population
 
     def place_initial_settlement(self, x: int, y: int, name: str = "Player"):
         pos = Position(x, y)
@@ -77,12 +82,20 @@ class Game:
         print("Game started with factions:")
         for faction in self.map.factions:
             print(f"- {faction.name} at {faction.settlement.position}")
+        print(f"Resources: {self.state.resources}")
+        print(f"Population: {self.state.population}")
+
+    def save(self) -> None:
+        self.state.resources = self.resources
+        self.state.population = self.population
+        save_state(self.state)
 
 def main():
     game = Game()
     # Example: player places settlement at (0,0)
     game.place_initial_settlement(0, 0)
     game.begin()
+    game.save()
 
 if __name__ == "__main__":
     main()

--- a/game/persistence.py
+++ b/game/persistence.py
@@ -1,0 +1,39 @@
+import json
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+
+SAVE_FILE = Path("save.json")
+TICK_DURATION = 1  # seconds per tick
+
+
+@dataclass
+class GameState:
+    timestamp: float
+    resources: int
+    population: int
+
+
+def load_state() -> GameState:
+    """Load the saved game state and grant offline gains."""
+    now = time.time()
+    if SAVE_FILE.exists():
+        with open(SAVE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        state = GameState(**data)
+        elapsed = now - state.timestamp
+        ticks = int(elapsed // TICK_DURATION)
+        if ticks > 0:
+            state.resources += state.population * ticks
+            state.timestamp = now
+    else:
+        state = GameState(timestamp=now, resources=0, population=0)
+    return state
+
+
+def save_state(state: GameState) -> None:
+    """Persist the current game state to disk."""
+    state.timestamp = time.time()
+    with open(SAVE_FILE, "w", encoding="utf-8") as f:
+        json.dump(asdict(state), f)


### PR DESCRIPTION
## Summary
- persist resources, population and timestamp in `game/persistence.py`
- load persisted state and compute offline gains
- show persisted resources when the game begins

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_68407cd85cf4832ba8da6695a8b8a56d